### PR TITLE
WIP - Flush arenas upon N mutate operations or time elapsed since last flush

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,18 @@ defer bq.Close()
 In this case, bigqueue will never allocate more memory than `4KB*10=40KB`. This
 memory is above and beyond the memory used in buffers for copying data.
 
+Bigqueue allows to set flush intervals based on either elapsed time or number of mutate operations.
+Flush syncs the in memory changes of memory mapped files with disk.  
+Note: This is a best effort flush and elapsed time and number of mutate operations are checked upon an enqueue/dequeue.
+```go
+bq, err := bigqueue.NewQueue("path/to/queue", bigqueue.SetFlushIntervalMutateOps(2))
+```
+In this case a flush is done after every two mutate operations.
+```go
+bq, err := bigqueue.NewQueue("path/to/queue", bigqueue.SetFlushElapsedDuration(time.Minute))
+```
+In this case a flush is done after one minute elapses.
+
 Write to bigqueue:
 ```go
 err := bq.Enqueue([]byte("elem"))   // size = 1

--- a/arena.go
+++ b/arena.go
@@ -14,6 +14,8 @@ const (
 // arena is an abstraction for a memory mapped file of a given size
 type arena struct {
 	mmap.File
+	// TODO: this flag is being touched from a lot of places, we need to encapsulate it's usage better
+	dirty bool
 }
 
 // newArena returns pointer to an arena. It takes a file location and mmaps it.

--- a/bigqueue_flush_test.go
+++ b/bigqueue_flush_test.go
@@ -1,0 +1,275 @@
+package bigqueue
+
+import (
+	"bytes"
+	"fmt"
+	"math"
+	"math/rand"
+	"os"
+	"path"
+	"testing"
+	"time"
+
+	"github.com/grandecola/mmap"
+	"github.com/jonboulle/clockwork"
+)
+
+func TestSetFlushIntervalMutateOpsValidation(t *testing.T) {
+	testDir := path.Join(os.TempDir(), fmt.Sprintf("testdir_%d", rand.Intn(1000)))
+	createTestDir(t, testDir)
+	defer deleteTestDir(t, testDir)
+
+	_, err := NewMmapQueue(testDir, SetFlushIntervalMutateOps(0))
+	if err != ErrMustBeGreaterThanZero {
+		t.Fatalf("expected error ErrMustBeGreaterThanZero, got: %v", err)
+	}
+}
+
+func TestSetFlushElapsedDurationValidation(t *testing.T) {
+	testDir := path.Join(os.TempDir(), fmt.Sprintf("testdir_%d", rand.Intn(1000)))
+	createTestDir(t, testDir)
+	defer deleteTestDir(t, testDir)
+
+	_, err := NewMmapQueue(testDir, SetFlushElapsedDuration(-1))
+	if err != ErrMustBeGreaterThanZero {
+		t.Fatalf("expected error ErrMustBeGreaterThanZero, got: %v", err)
+	}
+}
+
+func TestSetFlushIntervalMutateOps(t *testing.T) {
+	testDir := path.Join(os.TempDir(), fmt.Sprintf("testdir_%d", rand.Intn(1000)))
+	createTestDir(t, testDir)
+	defer deleteTestDir(t, testDir)
+
+	arenaSize := os.Getpagesize()
+	bq, err := NewMmapQueue(testDir, SetFlushIntervalMutateOps(4), SetArenaSize(arenaSize),
+		SetMaxInMemArenas(3))
+	if err != nil {
+		t.Fatalf("unable to get BigQueue: %v", err)
+	}
+	defer bq.Close()
+	setupFlushCountFile(bq, t)
+
+	// expectedIndex = true because of the putSize for a newly created queue
+	checkDirtiness(bq, t, true, [3]bool{false, false, false})
+	checkTimesCalled(bq, t, 0, [3]int{0, 0, 0})
+
+	msg := bytes.Repeat([]byte("a"), arenaSize)
+	if err := bq.Enqueue(msg); err != nil {
+		t.Fatalf("enqueue failed :: %v", err)
+	}
+
+	checkDirtiness(bq, t, true, [3]bool{true, true, false})
+	checkTimesCalled(bq, t, 0, [3]int{0, 0, 0})
+
+	if err := bq.Enqueue(msg); err != nil {
+		t.Fatalf("enqueue failed :: %v", err)
+	}
+
+	checkDirtiness(bq, t, true, [3]bool{true, true, true})
+	checkTimesCalled(bq, t, 0, [3]int{0, 0, 0})
+
+	if err := bq.Dequeue(); err != nil {
+		t.Fatalf("dequeue failed :: %v", err)
+	}
+
+	checkDirtiness(bq, t, true, [3]bool{true, true, true})
+	checkTimesCalled(bq, t, 0, [3]int{0, 0, 0})
+	checkMutateOps(bq, t, 3)
+
+	if err := bq.Dequeue(); err != nil {
+		t.Fatalf("dequeue failed :: %v", err)
+	}
+
+	checkDirtiness(bq, t, false, [3]bool{false, false, false})
+	checkTimesCalled(bq, t, 1, [3]int{1, 1, 1})
+	checkMutateOps(bq, t, 0)
+}
+
+func TestSetFlushElapsedDuration(t *testing.T) {
+	testDir := path.Join(os.TempDir(), fmt.Sprintf("testdir_%d", rand.Intn(1000)))
+	createTestDir(t, testDir)
+	defer deleteTestDir(t, testDir)
+
+	flushElapsedDuration := time.Second
+	arenaSize := os.Getpagesize()
+	clock := clockwork.NewFakeClock()
+
+	bq, err := NewMmapQueue(testDir, SetFlushElapsedDuration(flushElapsedDuration),
+		SetArenaSize(arenaSize), SetFlushIntervalMutateOps(math.MaxInt64),
+		SetMaxInMemArenas(3), setClock(clock))
+	if err != nil {
+		t.Fatalf("unable to get BigQueue: %v", err)
+	}
+	defer bq.Close()
+
+	setupFlushCountFile(bq, t)
+
+	checkDirtiness(bq, t, true, [3]bool{false, false, false})
+	checkTimesCalled(bq, t, 0, [3]int{0, 0, 0})
+
+	msg := []byte("a")
+	for i := 0; i < arenaSize/cInt64Size; i++ { // a lot of writes, but still no flush
+		if err := bq.Enqueue(msg); err != nil {
+			t.Fatalf("enqueue failed :: %v", err)
+		}
+	}
+
+	checkDirtiness(bq, t, true, [3]bool{true, true, false})
+	checkTimesCalled(bq, t, 0, [3]int{0, 0, 0})
+
+	clock.Advance(flushElapsedDuration)
+
+	if err := bq.Enqueue(msg); err != nil {
+		t.Fatalf("enqueue failed :: %v", err)
+	}
+
+	checkDirtiness(bq, t, false, [3]bool{false, false, false})
+	checkTimesCalled(bq, t, 1, [3]int{1, 1, 0})
+
+	clock.Advance(time.Second / 2)
+
+	for i := 0; i < arenaSize/cInt64Size; i++ {
+		if err := bq.Enqueue(msg); err != nil {
+			t.Fatalf("enqueue failed :: %v", err)
+		}
+	}
+
+	checkDirtiness(bq, t, true, [3]bool{false, true, true})
+	checkTimesCalled(bq, t, 1, [3]int{1, 1, 0})
+
+	clock.Advance(time.Second)
+
+	if err := bq.Enqueue(msg); err != nil {
+		t.Fatalf("enqueue failed :: %v", err)
+	}
+
+	checkDirtiness(bq, t, false, [3]bool{false, false, false})
+	checkTimesCalled(bq, t, 2, [3]int{1, 2, 1})
+}
+
+func TestResetOfBothFlushIntervalStates(t *testing.T) {
+	testDir := path.Join(os.TempDir(), fmt.Sprintf("testdir_%d", rand.Intn(1000)))
+	createTestDir(t, testDir)
+	defer deleteTestDir(t, testDir)
+
+	flushElapsedDuration := time.Second
+	clock := clockwork.NewFakeClock()
+
+	bq, err := NewMmapQueue(testDir, SetFlushElapsedDuration(flushElapsedDuration),
+		SetFlushIntervalMutateOps(2),
+		setClock(clock))
+
+	if err != nil {
+		t.Fatalf("unable to get BigQueue: %v", err)
+	}
+	defer bq.Close()
+
+	msg := []byte("a")
+	if err := bq.Enqueue(msg); err != nil {
+		t.Fatalf("enqueue failed :: %v", err)
+	}
+
+	checkMutateOps(bq, t, 1)
+	clock.Advance(flushElapsedDuration) // time interval reached, flush happens, resets both prevFlushTime, mutateOps
+
+	if err := bq.Enqueue(msg); err != nil {
+		t.Fatalf("enqueue failed :: %v", err)
+	}
+
+	checkMutateOps(bq, t, 0)
+	prevFlushTime := (bq.(*MmapQueue)).prevFlushTime
+	if prevFlushTime != clock.Now() {
+		t.Fatalf("expected prevFlushTime: %v to be reset to clock's now: %v", prevFlushTime, clock.Now())
+	}
+
+	clock.Advance(flushElapsedDuration / 2) // time moves ahead
+
+	if err := bq.Enqueue(msg); err != nil {
+		t.Fatalf("enqueue failed :: %v", err)
+	}
+	if err := bq.Enqueue(msg); err != nil {
+		t.Fatalf("enqueue failed :: %v", err)
+	}
+
+	// flush after 2 mutateOps, causes mutateOps reset and time reset to Now()
+
+	checkMutateOps(bq, t, 0)
+	prevFlushTime = (bq.(*MmapQueue)).prevFlushTime
+	if prevFlushTime != clock.Now() {
+		t.Fatalf("expected prevFlushTime: %v to be reset to clock's now: %v", prevFlushTime, clock.Now())
+	}
+
+}
+
+type flushCountingFile struct {
+	mmap.File
+	timesCalled int
+}
+
+func (m *flushCountingFile) Flush(flags int) error {
+	m.timesCalled++
+	return m.File.Flush(flags)
+}
+
+func setupFlushCountFile(q Queue, t *testing.T) {
+	bq := q.(*MmapQueue)
+	for i := 0; i < bq.conf.maxInMemArenas; i++ {
+		arena, err := bq.am.getArena(i)
+		if err != nil {
+			t.Fatalf("test setup failed, could not load arena %d because: %v", i, err)
+		}
+		arena.File = &flushCountingFile{arena.File, 0}
+	}
+	bq.index.indexArena.File = &flushCountingFile{bq.index.indexArena.File, 0}
+}
+
+func checkMutateOps(q Queue, t *testing.T, expected int64) {
+	bq := q.(*MmapQueue)
+	if bq.mutateOpsSinceFlush != expected {
+		t.Fatalf("expected mutateOpsSinceFlush %d, got %d", expected, bq.mutateOpsSinceFlush)
+	}
+}
+
+// expects first three arenas to be in memory
+func checkTimesCalled(q Queue, t *testing.T, indexTimesCalled int, timesCalled [3]int) {
+	bq := q.(*MmapQueue)
+	for i, expected := range timesCalled {
+		arena := bq.am.arenaList[i]
+		switch m := arena.File.(type) {
+		case *flushCountingFile:
+			if m.timesCalled != expected {
+				t.Fatalf("arena %d mmap flushed %d times, expected %d", i, m.timesCalled, 1)
+			}
+		default:
+			t.Fatalf("expected arena %d mmap to be of type *flushCountingFile, but is %T", i, m)
+		}
+	}
+
+	switch m := bq.index.indexArena.File.(type) {
+	case *flushCountingFile:
+		if m.timesCalled != indexTimesCalled {
+			t.Fatalf("index arena mmap flushed %d times, expected %d", m.timesCalled, 1)
+		}
+	default:
+		t.Fatalf("index arena mmap expected to be of type *flushCountingFile, but is %T", m)
+	}
+}
+
+// expects first three arenas to be in memory
+func checkDirtiness(q Queue, t *testing.T, expectedIndex bool, expectedArenas [3]bool) {
+	bq := q.(*MmapQueue)
+	if bq.index.indexArena.dirty != expectedIndex {
+		t.Fatalf("dirty flag for index expected %v, got %v", expectedIndex, bq.index.indexArena.dirty)
+	}
+
+	for i, expected := range expectedArenas {
+		arena := bq.am.arenaList[i]
+		if arena == nil {
+			t.Fatalf("aid %d is nil, expected it to be in memory", i)
+		}
+		if arena.dirty != expected {
+			t.Fatalf("dirty flag for arena %d expected %v, got %v", i, expected, arena.dirty)
+		}
+	}
+}

--- a/config.go
+++ b/config.go
@@ -3,6 +3,9 @@ package bigqueue
 import (
 	"errors"
 	"os"
+	"time"
+
+	"github.com/jonboulle/clockwork"
 )
 
 const (
@@ -10,6 +13,10 @@ const (
 
 	// tail, head and a buffer arena, hence 3
 	cMinMaxInMemArenas = 3
+
+	// values chosen arbitrarily
+	cFlushIntervalMutateOps = 1000
+	cFlushElapsedDuration   = time.Minute
 )
 
 var (
@@ -17,12 +24,21 @@ var (
 	ErrTooSmallArenaSize = errors.New("too small arena size")
 	// ErrTooFewInMemArenas is returned when number of arenas allowed in memory < 3
 	ErrTooFewInMemArenas = errors.New("too few in memory arenas")
+	// ErrMustBeGreaterThanZero is returned when either flushing after a number of mutate ops
+	// or after an elapsed duration is not greater than zero
+	ErrMustBeGreaterThanZero = errors.New("must be greater than zero")
+	// singleton instance of real clock.
+	// TODO: not needed once https://github.com/jonboulle/clockwork/pull/14 is merged
+	realClock = clockwork.NewRealClock()
 )
 
 // bqConfig stores all the configuration related to bigqueue
 type bqConfig struct {
-	arenaSize      int
-	maxInMemArenas int
+	arenaSize              int
+	maxInMemArenas         int
+	flushIntervalMutateOps int64
+	flushElapsedDuration   time.Duration
+	clock                  clockwork.Clock
 }
 
 // Option is function type that takes a bqConfig object
@@ -32,8 +48,11 @@ type Option func(*bqConfig) error
 // newConfig creates an object of bqConfig with default parameter values
 func newConfig() *bqConfig {
 	return &bqConfig{
-		arenaSize:      cDefaultArenaSize,
-		maxInMemArenas: cMinMaxInMemArenas,
+		arenaSize:              cDefaultArenaSize,
+		maxInMemArenas:         cMinMaxInMemArenas,
+		flushIntervalMutateOps: cFlushIntervalMutateOps,
+		flushElapsedDuration:   cFlushElapsedDuration,
+		clock:                  realClock,
 	}
 }
 
@@ -64,6 +83,50 @@ func SetMaxInMemArenas(maxInMemArenas int) Option {
 		}
 
 		c.maxInMemArenas = maxInMemArenas
+		return nil
+	}
+}
+
+// SetFlushIntervalMutateOps returns an Option that sets the number of
+// mutate operations (enqueue/dequeue) after which the queue's in-memory changes
+// will be flushed to disk.
+//
+// Note: This is a best effort flush and number of mutate operations is checked upon an enqueue/dequeue.
+//
+// For durability this value should be low.
+// For performance this value should be high.
+func SetFlushIntervalMutateOps(flushIntervalMutateOps int64) Option {
+	return func(c *bqConfig) error {
+		if flushIntervalMutateOps < 1 {
+			return ErrMustBeGreaterThanZero
+		}
+		c.flushIntervalMutateOps = flushIntervalMutateOps
+		return nil
+	}
+}
+
+// SetFlushElapsedDuration returns an Option that sets the minimum time to elapse
+// since the last flush after which the queue's in-memory changes
+// will be flushed to disk.
+//
+// Note: This is a best effort flush and elapsed time is checked upon an enqueue/dequeue.
+//
+// For durability this value should be low.
+// For performance this value should be high.
+func SetFlushElapsedDuration(flushElapsedDuration time.Duration) Option {
+	// TODO: in future we should do a timely flush from a background scheduled goroutine
+	return func(c *bqConfig) error {
+		if flushElapsedDuration < 1 {
+			return ErrMustBeGreaterThanZero
+		}
+		c.flushElapsedDuration = flushElapsedDuration
+		return nil
+	}
+}
+
+func setClock(clock clockwork.Clock) Option {
+	return func(c *bqConfig) error {
+		c.clock = clock
 		return nil
 	}
 }

--- a/doc.go
+++ b/doc.go
@@ -25,6 +25,18 @@
 // In this case, bigqueue will never allocate more memory than `4KB*10=40KB`. This
 // memory is above and beyond the memory used in buffers for copying data.
 //
+// bigqueue allows to set flush intervals based on either elapsed time or number of mutate operations.
+// Flush syncs the in memory changes of memory mapped files with disk.
+// Note: This is a best effort flush and elapsed time and number of mutate operations are checked upon an enqueue/dequeue.
+//
+//  bq, err := bigqueue.NewQueue("path/to/queue", bigqueue.SetFlushIntervalMutateOps(2))
+//
+// In this case a flush is done after every two mutate operations.
+//
+//  bq, err := bigqueue.NewQueue("path/to/queue", bigqueue.SetFlushElapsedDuration(time.Minute))
+//
+// In this case a flush is done after one minute elapses.
+//
 // Write to bigqueue:
 //
 //	err := bq.Enqueue([]byte("elem"))   // size = 1

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/grandecola/bigqueue
 require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/grandecola/mmap v0.4.0
+	github.com/jonboulle/clockwork v0.1.1-0.20190114141812-62fb9bc030d1
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/stretchr/testify v1.2.2
 )

--- a/go.sum
+++ b/go.sum
@@ -2,6 +2,8 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/grandecola/mmap v0.4.0 h1:MYPAjq2SnrOriZ7wHPIvQy00rSI3RcuulZvMV9WdIdc=
 github.com/grandecola/mmap v0.4.0/go.mod h1:D5tgFYWkYaB2UvX+PxyZcHz/0eHWh/LeTk16q7iGS6I=
+github.com/jonboulle/clockwork v0.1.1-0.20190114141812-62fb9bc030d1 h1:qBCV/RLV02TSfQa7tFmxTihnG+u+7JXByOkhlkR5rmQ=
+github.com/jonboulle/clockwork v0.1.1-0.20190114141812-62fb9bc030d1/go.mod h1:Ii8DK3G1RaLaWxj9trq07+26W01tbo22gdxWY5EU2bo=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/stretchr/testify v1.2.2 h1:bSDNvY7ZPG5RlJ8otE/7V6gMiyenm9RtJ7IUVIAoJ1w=

--- a/index.go
+++ b/index.go
@@ -50,6 +50,7 @@ func (i *queueIndex) getHead() (int, int) {
 func (i *queueIndex) putHead(aid, pos int) {
 	i.indexArena.WriteUint64At(uint64(aid), 0)
 	i.indexArena.WriteUint64At(uint64(pos), 8)
+	i.indexArena.dirty = true
 }
 
 // getTail reads the values of tail of the queue from the index arena.
@@ -72,6 +73,7 @@ func (i *queueIndex) getTail() (int, int) {
 func (i *queueIndex) putTail(aid, pos int) {
 	i.indexArena.WriteUint64At(uint64(aid), 16)
 	i.indexArena.WriteUint64At(uint64(pos), 24)
+	i.indexArena.dirty = true
 }
 
 // getArenaSize reads the value of arena size from index
@@ -88,6 +90,7 @@ func (i *queueIndex) getArenaSize() int {
 // putArenaSize writes the value of arena size in the index arena
 func (i *queueIndex) putArenaSize(arenaSize int) {
 	i.indexArena.WriteUint64At(uint64(arenaSize), 32)
+	i.indexArena.dirty = true
 }
 
 // flush writes the memory state of the index arena on to disk

--- a/read.go
+++ b/read.go
@@ -108,7 +108,9 @@ func (q *MmapQueue) Dequeue() error {
 	offset = (offset + length) % q.conf.arenaSize
 	q.index.putHead(aid, offset)
 
-	return nil
+	q.mutateOpsSinceFlush++
+
+	return q.flushIfRequired()
 }
 
 // peek reads one element of the queue into given reader.


### PR DESCRIPTION
Fixes #41  

Allow to make durability vs performance choices by choosing explicit flush intervals in two ways:
* Flush when number of mutate operations (enqueue/dequeue) has become more than a threshold
* Elapsed time since previous flush has become more than a certain duration